### PR TITLE
Enable pointer events for mobile controls

### DIFF
--- a/frontend/src/components/TouchControls.vue
+++ b/frontend/src/components/TouchControls.vue
@@ -2,22 +2,21 @@
   <div class="touch-controls">
     <button
       class="control"
-      @touchstart.prevent="controls.pressLeft"
-      @touchend.prevent="controls.releaseLeft"
-      @mousedown.prevent="controls.pressLeft"
-      @mouseup.prevent="controls.releaseLeft"
+      @pointerdown.prevent="controls.pressLeft"
+      @pointerup.prevent="controls.releaseLeft"
+      @pointercancel.prevent="controls.releaseLeft"
+      @pointerleave.prevent="controls.releaseLeft"
     >◀</button>
     <button
       class="control"
-      @touchstart.prevent="controls.shoot"
-      @mousedown.prevent="controls.shoot"
+      @pointerdown.prevent="controls.shoot"
     >●</button>
     <button
       class="control"
-      @touchstart.prevent="controls.pressRight"
-      @touchend.prevent="controls.releaseRight"
-      @mousedown.prevent="controls.pressRight"
-      @mouseup.prevent="controls.releaseRight"
+      @pointerdown.prevent="controls.pressRight"
+      @pointerup.prevent="controls.releaseRight"
+      @pointercancel.prevent="controls.releaseRight"
+      @pointerleave.prevent="controls.releaseRight"
     >▶</button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- switch touch controls to use modern `pointer` events so mobile users can move left/right and shoot

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684058b9fa48832c982bbb93a71b5006